### PR TITLE
Dimension casting causing wrong numpy array conversions on windows

### DIFF
--- a/source/pwrapper/numpyWrap.cpp
+++ b/source/pwrapper/numpyWrap.cpp
@@ -65,11 +65,11 @@ PyArrayContainer::ExtractData(void *_pParentPyArray)
 	PyArrayObject *pParent = reinterpret_cast<PyArrayObject *>(pParentPyArray);
 
 	int numDims = PyArray_NDIM(pParent);
-	long* pDims = (long*)PyArray_DIMS(pParent);
+	intptr_t* pDims = PyArray_DIMS(pParent);
 
 	pData 		= PyArray_DATA(pParent);
 	TotalSize 	= PyArray_SIZE(pParent);
-	Dims 		= std::vector<long>(&pDims[0], &pDims[numDims]);
+	Dims = std::vector<int>(pDims, pDims + numDims);
 
 	int iDataType = PyArray_TYPE(pParent);
 	switch(iDataType) {

--- a/source/pwrapper/numpyWrap.h
+++ b/source/pwrapper/numpyWrap.h
@@ -60,7 +60,7 @@ namespace Manta
 			void *pData;
 			NumpyTypes DataType;
 			unsigned int TotalSize;
-			std::vector<long> Dims;
+			std::vector<int> Dims;
 		private:
 			void *pParentPyArray;
 	};


### PR DESCRIPTION
On windows, the cast to `long`  from the type `npy_intp` returned by [`PyArray_NDIMS`](https://numpy.org/doc/stable/reference/c-api/array.html?highlight=pyarray_ndims#c.PyArray_DIMS) results in incorrect parsing of numpy array dimensions. I propose the [use of `intptr_t`](https://stackoverflow.com/a/6326362) as a solution with the consequent change of type of the vector `Dims` to `int`.